### PR TITLE
[FE] Feat: 로그인 페이지를 위한 컴포넌트 생성 및 css reset 재설정

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7190,10 +7190,10 @@
         "supports-color": "^5.5.0"
       }
     },
-    "styled-normalize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
-      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ=="
+    "styled-reset": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.3.4.tgz",
+      "integrity": "sha512-1UmkWmRwSPfzolKleyPjbZdBqkxSXv5ImqTP5WeSjWk0Z7IvEzsrYhrqinZfCg10eM1P6BEtFly8+puQJnN/0A=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "styled-components": "^5.3.0",
-    "styled-normalize": "^8.0.7"
+    "styled-reset": "^4.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import GlobalStyle from './styles/GlobalStyle';
-import LoginPage from './pages/LoginPage';
+import GlobalStyle from 'styles/GlobalStyle';
+import LoginPage from 'pages/Login/Login';
 
 const App = () => {
   return (
@@ -18,3 +18,5 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById('root'),
 );
+
+// 글로벌 스타일 적용 안되는 것 수정하기

--- a/frontend/src/components/Input/Input.styled.ts
+++ b/frontend/src/components/Input/Input.styled.ts
@@ -6,7 +6,7 @@ export const SInput = styled.input`
   background-color: #f7f7f7;
   border-radius: 0.5rem;
   font-size: 1rem;
-  padding: 15px;
+  padding: 1rem;
   :focus {
     background-color: #ffffff;
     outline: none;

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SInput } from './style';
+import { SInput } from './Input.styled';
 
 interface Props {
   placeholder?: string;

--- a/frontend/src/modules/LoginLayout/LoginLayout.styled.ts
+++ b/frontend/src/modules/LoginLayout/LoginLayout.styled.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 600px;
+  height: 500px;
+  padding: 1rem;
+  background-color: #ffffff;
+  margin: 0 auto;
+`;

--- a/frontend/src/modules/LoginLayout/LoginLayout.tsx
+++ b/frontend/src/modules/LoginLayout/LoginLayout.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import Input from 'components/atoms/Input';
+import Input from 'components/Input/Input';
 import { PLACEHOLDER } from 'constants/placeholder';
+import { Container } from './LoginLayout.styled';
 
 const LoginModule = (): React.ReactElement => {
   return (
-    <>
+    <Container>
       <Input placeholder={PLACEHOLDER.LOGIN_EMAIL} />
-    </>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import LoginModule from 'components/modules/LoginModule';
+import LoginLayout from 'modules/LoginLayout/LoginLayout';
 
 const LoginPage = (): React.ReactElement => {
   return (
     <>
-      <LoginModule />
+      <LoginLayout />
     </>
   );
 };

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -1,13 +1,18 @@
 import { createGlobalStyle } from 'styled-components';
-import { normalize } from 'styled-normalize';
+import reset from 'styled-reset';
 
 const GlobalStyle = createGlobalStyle`
-  ${normalize}
+  ${reset}
+  * {
+    box-sizing: border-box;
+  }
   html {
     height: 100%;
     background-color: #FFDEE9;
     background-image: linear-gradient(0deg, #FFDEE9 0%, #B5FFFC 100%);
-    font-family: Arial, Helvetica, sans-serif;
+  }
+  body {
+    font-family: Arial, Helvetica, sans-serif;  
   }
 `;
 


### PR DESCRIPTION
### 작업 내용

- 로그인 레이아웃, 인풋 컴포넌트 생성
- styled-normalize -> styled-reset으로 변경

### 주의 사항

- 없음

closes #31 
